### PR TITLE
Have Jenkins check out the correct ableC branch automatically

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -101,7 +101,7 @@ node {
                    ]
                  ])
       }
-      except (e) {
+      catch (e) {
         checkout([ $class: 'GitSCM',
                    branches: [[name: '*/develop']],
                    doGenerateSubmoduleConfigurations: false,

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -73,30 +73,49 @@ node {
       /* don't check out extension under ableC_Home because doing so would allow
        * the Makefiles to find ableC with the included search paths, but we want
        * to explicitly specify the path to ableC according to ABLEC_BASE */
-    checkout([ $class: 'GitSCM',
-               branches: scm.branches,
-               doGenerateSubmoduleConfigurations: scm.doGenerateSubmoduleConfigurations,
-               extensions: [
-                 [ $class: 'RelativeTargetDirectory',
-                   relativeTargetDir: "extensions/${extension_name}"],
-                 [ $class: 'CleanCheckout']
-                 ],
-               submoduleCfg: scm.submoduleCfg,
-               userRemoteConfigs: scm.userRemoteConfigs
-             ])
-
       checkout([ $class: 'GitSCM',
-                 branches: [[name: '*/develop']],
-                 doGenerateSubmoduleConfigurations: false,
+                 branches: scm.branches,
+                 doGenerateSubmoduleConfigurations: scm.doGenerateSubmoduleConfigurations,
                  extensions: [
                    [ $class: 'RelativeTargetDirectory',
-                     relativeTargetDir: 'ableC'],
+                     relativeTargetDir: "extensions/${extension_name}"],
                    [ $class: 'CleanCheckout']
-                 ],
-                 userRemoteConfigs: [
-                   [url: 'https://github.com/melt-umn/ableC.git']
-                 ]
+                   ],
+                 submoduleCfg: scm.submoduleCfg,
+                 userRemoteConfigs: scm.userRemoteConfigs
                ])
+
+      /* Try checking out an ableC branch with the same name, if that fails then
+       * check out develop */
+      try {
+        checkout([ $class: 'GitSCM',
+                   branches: scm.branches,
+                   doGenerateSubmoduleConfigurations: false,
+                   extensions: [
+                     [ $class: 'RelativeTargetDirectory',
+                       relativeTargetDir: 'ableC'],
+                     [ $class: 'CleanCheckout']
+                   ],
+                   userRemoteConfigs: [
+                     [url: 'https://github.com/melt-umn/ableC.git']
+                   ]
+                 ])
+      }
+      except (e) {
+        checkout([ $class: 'GitSCM',
+                   branches: [[name: '*/develop']],
+                   doGenerateSubmoduleConfigurations: false,
+                   extensions: [
+                     [ $class: 'RelativeTargetDirectory',
+                       relativeTargetDir: 'ableC'],
+                     [ $class: 'CleanCheckout']
+                   ],
+                   userRemoteConfigs: [
+                     [url: 'https://github.com/melt-umn/ableC.git']
+                   ]
+                 ])
+      }
+      
 
       /* env.PATH is the master's path, not the executor's */
       withEnv(env) {


### PR DESCRIPTION
This will try first checking out an ableC branch with the same name as the current branch, and if that fails then checkout develop.  
I'm going to go ahead and merge this and update extensions in a similar way soon if there are no objections.  